### PR TITLE
Required parameters cannot follow optional parameters

### DIFF
--- a/bitvavo.php
+++ b/bitvavo.php
@@ -361,7 +361,7 @@ function sortAndInsert($update, $book, $sortFunc) {
 }
 
 class Websocket {
-  public function __construct($bitvavo = null, $reconnect = false, $publicCommandArray, $privateCommandArray, $oldSocket) {
+  public function __construct($bitvavo, $reconnect, $publicCommandArray, $privateCommandArray, $oldSocket) {
     $this->parent = $bitvavo;
     $this->wsurl = $bitvavo->wsurl;
     $this->apiKey = $bitvavo->apiKey;


### PR DESCRIPTION
This PR solves the below PHP warnings:

PHP Deprecated:  Required parameter $publicCommandArray follows optional parameter $bitvavo in ../vendor/bitvavo/php-bitvavo-api/bitvavo.php on line 364
PHP Deprecated:  Required parameter $privateCommandArray follows optional parameter $bitvavo in ../vendor/bitvavo/php-bitvavo-api/bitvavo.php on line 364
PHP Deprecated:  Required parameter $oldSocket follows optional parameter $bitvavo in ../vendor/bitvavo/php-bitvavo-api/bitvavo.php on line 364